### PR TITLE
Resolve issue #7

### DIFF
--- a/Elmah.SqlServer.EFInitializer.sln
+++ b/Elmah.SqlServer.EFInitializer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elmah.SqlServer.EFInitializer", "Elmah.SqlServer.EFInitializer\Elmah.SqlServer.EFInitializer.csproj", "{6D258795-5275-4C1B-868F-B6A20B25F953}"
 EndProject
@@ -14,14 +14,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{0788A1
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug-NET40|Any CPU = Debug-NET40|Any CPU
+		Debug-NET45|Any CPU = Debug-NET45|Any CPU
+		Release-NET40|Any CPU = Release-NET40|Any CPU
+		Release-NET45|Any CPU = Release-NET45|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug-NET40|Any CPU.ActiveCfg = Debug-NET40|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug-NET40|Any CPU.Build.0 = Debug-NET40|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug-NET45|Any CPU.ActiveCfg = Debug-NET45|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Debug-NET45|Any CPU.Build.0 = Debug-NET45|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release-NET40|Any CPU.ActiveCfg = Release-NET40|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release-NET40|Any CPU.Build.0 = Release-NET40|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release-NET45|Any CPU.ActiveCfg = Release-NET45|Any CPU
+		{6D258795-5275-4C1B-868F-B6A20B25F953}.Release-NET45|Any CPU.Build.0 = Release-NET45|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Elmah.SqlServer.EFInitializer/Elmah.SqlServer.EFInitializer.csproj
+++ b/Elmah.SqlServer.EFInitializer/Elmah.SqlServer.EFInitializer.csproj
@@ -14,28 +14,46 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-NET45|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug-NET45\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-NET45|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Release-NET45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
-    </Reference>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-NET40|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug-NET40\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-NET40|AnyCPU'">
+    <OutputPath>bin\Release-NET40\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(Configuration)'=='Debug-NET45' Or '$(Configuration)'=='Release-NET45'">
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.dll</HintPath>
@@ -43,6 +61,22 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)'=='Debug-NET40' Or '$(Configuration)'=='Release-NET40'">
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\EntityFramework.6.1.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -86,7 +120,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="content\Web.config.transform" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Elmah.SqlServer.EFInitializer/packages.config
+++ b/Elmah.SqlServer.EFInitializer/packages.config
@@ -5,4 +5,9 @@
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.0.5" targetFramework="net45" />
+
+  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.1" targetFramework="net40" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
+  <package id="WebActivatorEx" version="2.0.5" targetFramework="net40" />
 </packages>

--- a/NuGetPack.bat
+++ b/NuGetPack.bat
@@ -1,9 +1,11 @@
 @echo off
 set /p version="Version: "
-msbuild Elmah.SqlServer.EFInitializer.sln /P:Configuration=Release
-rmdir /S /Q content
-rmdir /S /Q lib
+msbuild Elmah.SqlServer.EFInitializer.sln /P:Configuration=Release-NET40
+msbuild Elmah.SqlServer.EFInitializer.sln /P:Configuration=Release-NET45
+rmdir /S /Q nuget-pack\content
+rmdir /S /Q nuget-pack\lib
 xcopy Elmah.SqlServer.EFInitializer\content nuget-pack\content\ /S /Y
-xcopy Elmah.SqlServer.EFInitializer\bin\Release\Elmah.SqlServer.EFInitializer.dll nuget-pack\lib\4.5\ /Y
+xcopy Elmah.SqlServer.EFInitializer\bin\Release-NET40\Elmah.SqlServer.EFInitializer.dll nuget-pack\lib\net40\ /Y
+xcopy Elmah.SqlServer.EFInitializer\bin\Release-NET45\Elmah.SqlServer.EFInitializer.dll nuget-pack\lib\net45\ /Y
 .nuget\nuget pack nuget-pack\Elmah.SqlServer.EFInitializer.nuspec -Version %version%
 pause


### PR DESCRIPTION
Multiple target frameworks support added to the project as described [here](http://shazwazza.com/post/multi-targeting-a-single-net-project-to-build-for-different-framework-versions/).
So EFInitializer now may be referenced both from NET 4.0 and NET 4.5 projects.
